### PR TITLE
Add bootstrap to bower so ember can run

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "showdown": "^1.4.2"
+    "showdown": "^1.4.2",
+    "bootstrap": "*"
   }
 }


### PR DESCRIPTION
bootstrap was imported in ember-cli-build but not included in bower.  This fixes it.  Not sure which version intended, so left it as star.
